### PR TITLE
Rozszerzenie i refaktoryzacja `column_type`

### DIFF
--- a/eda/components/statistics.py
+++ b/eda/components/statistics.py
@@ -2,7 +2,9 @@ from io import StringIO
 
 from dash import dcc, html, callback, Input, Output, State, dash_table, no_update
 from dash.exceptions import PreventUpdate
+
 from eda.destats import *
+from eda.data_table.column_type import is_number_type
 
 
 def register_1d_stats_callbacks():
@@ -53,7 +55,7 @@ def register_1d_stats_callbacks():
         df = pd.DataFrame(data)
         values = df[col]
 
-        if dtypes[col] == 'int64' or dtypes[col] == 'float64':
+        if is_number_type(dtypes[col]):
             return info, numeric_stats(values)
         else:
             return info, categorical_stats(values)
@@ -122,7 +124,7 @@ def register_1d_stats_callbacks():
         df = pd.DataFrame(data)
         values = df[col]
 
-        if dtypes[col] == 'int64' or dtypes[col] == 'float64':
+        if is_number_type(dtypes[col]):
             return numeric_tables(values)
         else:
             return categorical_tables(values)

--- a/eda/data_table/column_type.py
+++ b/eda/data_table/column_type.py
@@ -1,5 +1,26 @@
-import pandas as pd
+from collections import namedtuple
+from typing import Literal, NamedTuple
 import re
+import pandas as pd
+
+ColumnType = Literal[
+    "int64",
+    "float64",
+    "datetime64",
+    "object",
+    "category",
+]
+ColumnInfo = NamedTuple("ColumnInfo", [
+    ("name", str),
+    ("type", ColumnType),
+])
+column_info = (
+    ColumnInfo(name="Integer", type="int64"),
+    ColumnInfo(name="Float", type="float64"),
+    ColumnInfo(name="Datetime", type="datetime64"),
+    ColumnInfo(name="String", type="object"),
+    ColumnInfo(name="Categorical", type="category"),
+)
 
 __NUMBER_REGEX = re.compile(r"^\d+([,\.]\d+)?$")
 __INT_REGEX = re.compile(r"^\d+([,\.]0)?$")
@@ -34,29 +55,47 @@ def is_float_column(column: pd.Series) -> bool:
     return column.apply(__is_float).any()
 
 
-def convert_column_data_type(df, col, dtype):
-    if dtype == "object":
-        df[col] = df[col].astype(str)
-    elif dtype == "int64":
-        df[col] = pd.to_numeric(
-                df[col],
-                downcast="integer",
-                errors="raise") \
-            .astype("Int64")
-    elif dtype == "float64":
-        if df[col].dtype == "object":
-            df[col] = pd.to_numeric(
-                df[col].str.replace(",", "."),
-                errors="coerce"
+def is_number_type(column_type: str) -> bool:
+    return column_type == column_info[0].type \
+        or column_type == column_info[1].type
+
+
+def convert_numeric_strings_to_numbers(df: pd.DataFrame) -> None:
+    for name, values in df.items():
+        if values.dtype == "object" or values.dtype == "float64":
+            if is_int_column(values):
+                convert_column_data_type(df, name, "int64")
+            elif is_float_column(values):
+                convert_column_data_type(df, name, "float64")
+
+
+def convert_column_data_type(
+    df: pd.DataFrame,
+    column_name: str,
+    column_type: ColumnType
+) -> None:
+    column = df[column_name]
+    match column_type:
+        case "object":
+            df[column_name] = column.astype(str)
+        case "int64":
+            df[column_name] = pd.to_numeric(
+                    column,
+                    downcast="integer") \
+                .astype("Int64")
+        case "float64":
+            if column.dtype == "object":
+                df[column_name] = pd.to_numeric(
+                    column.str.replace(",", "."),
+                    errors="coerce"
+                )
+            else:
+                df[column_name] = pd.to_numeric(column)
+        case "datetime64":
+            datetime_pattern = "%Y-%m-%dT%H:%M:%S"
+            df[column_name] = pd.to_datetime(
+                column,
+                format=datetime_pattern
             )
-        else:
-            df[col] = pd.to_numeric(df[col])
-    elif dtype == "datetime64":
-        datetime_pattern = "%Y-%m-%dT%H:%M:%S"
-        df[col] = pd.to_datetime(
-            df[col],
-            errors="raise",
-            format=datetime_pattern
-        )
-    elif dtype == "category":
-        df[col] = df[col].astype("category")
+        case "category":
+            df[column_name] = column.astype("category")

--- a/eda/data_table/data_table.py
+++ b/eda/data_table/data_table.py
@@ -14,9 +14,9 @@ from dash import (
 )
 
 from eda.data_table.column_type import (
+    column_info,
+    convert_numeric_strings_to_numbers,
     convert_column_data_type,
-    is_int_column,
-    is_float_column,
 )
 
 
@@ -29,12 +29,7 @@ def register_dataframe_callbacks():
     def render(df_json: str):
         df = pd.read_json(StringIO(df_json))
 
-        for name, values in df.items():
-            if values.dtype == "object" or values.dtype == "float64":
-                if is_int_column(values):
-                    convert_column_data_type(df, name, "int64")
-                elif is_float_column(values):
-                    convert_column_data_type(df, name, "float64")
+        convert_numeric_strings_to_numbers(df)
 
         string_dtypes = df.dtypes.astype(str).str.lower()
         json_dataframe = df.to_json(date_format="iso")
@@ -91,11 +86,11 @@ def register_dataframe_callbacks():
                     dcc.Dropdown(
                         id={'type-dropdown': column_name},
                         options=[
-                            {'label': 'String', 'value': 'object'},
-                            {'label': 'Integer', 'value': 'int64'},
-                            {'label': 'Float', 'value': 'float64'},
-                            {'label': 'Datetime', 'value': 'datetime64'},
-                            {'label': 'Categorical', 'value': 'category'},
+                            {
+                                "label": cinfo.name,
+                                "value": cinfo.type
+                            }
+                            for cinfo in column_info
                         ],
                         value=column_type
                     )


### PR DESCRIPTION
Naprawiłem błąd ze złym wykrywaniem typów, gdy pojawiała się brakująca wartość - zmienne liczbowe były traktowane zawsze jako floaty. Dodałem nowy typ, krotkę nazwaną oraz listę z informacjami dotyczącej kolumn, które obsługujemy, a także dwie nowe funkcje (jedną z nich przeniosłem z `data_table.render`). Dodatkowo zrefaktoryzowałem `convert_column_data_type`, aby korzystać z **match case**.