### PR TITLE
Wykresy statystyk 1D

### DIFF
--- a/eda/components/statistics_1d.py
+++ b/eda/components/statistics_1d.py
@@ -256,13 +256,12 @@ def register_1d_stats_callbacks():
             raise PreventUpdate
 
         df = pd.DataFrame(data)
-        values = df[column]
 
-        value_counts = values.value_counts().reset_index()
-        value_counts.columns = ['Wartość', 'Liczba wystąpień']
+        fig = px.histogram(df, x=column, nbins=10,  # You can adjust 'nbins' as needed
+                           title=f'Histogram wartości dla {column}',
+                           labels={'count': 'Liczba wystąpień', column: 'Wartość'})
 
-        fig = px.bar(value_counts, x='Wartość', y='Liczba wystąpień',
-                     title=f'Liczba wystąpień każdej unikalnej wartości dla {column}')
+        fig.update_layout(yaxis_title='Liczba wystąpień')
 
         return dcc.Graph(figure=fig)
 
@@ -284,7 +283,6 @@ def register_1d_stats_callbacks():
         value_counts.columns = ['Wartość', 'Liczba wystąpień']
         value_counts['Wartość'] = value_counts['Wartość'].astype(str)
 
-        # Sortowanie wartości malejąco według liczby wystąpień
         value_counts = value_counts.sort_values(by='Liczba wystąpień', ascending=False)
 
         fig = px.bar(value_counts, x='Wartość', y='Liczba wystąpień',

--- a/eda/components/statistics_1d.py
+++ b/eda/components/statistics_1d.py
@@ -66,7 +66,7 @@ def register_1d_stats_callbacks():
         values = df[col]
 
         if is_number_type(dtypes[col]):
-            return info, numeric_stats(values), None, None
+            return info, numeric_stats(values), html.Button('Wygeneruj wykres słupkowy', id="make-categorical-chart"), None
         else:
             return info, categorical_stats(values), html.Button('Wygeneruj wykres słupkowy', id="make-categorical-chart"), None
 
@@ -250,9 +250,9 @@ def register_1d_stats_callbacks():
         values = df[column]
 
         value_counts = values.value_counts().reset_index()
-        value_counts.columns = ['Value', 'Count']
+        value_counts.columns = ['Wartość', 'Liczba wystąpień']
 
-        fig = px.bar(value_counts, x='Value', y='Count',
+        fig = px.bar(value_counts, x='Wartość', y='Liczba wystąpień',
                      title=f'Liczba wystąpień każdej unikalnej wartości dla {column}')
 
         return dcc.Graph(figure=fig)

--- a/eda/components/statistics_1d.py
+++ b/eda/components/statistics_1d.py
@@ -294,7 +294,6 @@ def register_1d_stats_callbacks():
             raise PreventUpdate
 
         df = pd.DataFrame(data)
-
         fig = px.box(df, y=column, title=f'Wykres pudełkowy dla kolumny {column}')
 
         return dcc.Graph(figure=fig)

--- a/eda/components/statistics_1d.py
+++ b/eda/components/statistics_1d.py
@@ -1,4 +1,3 @@
-import math
 from io import StringIO
 
 from dash import dcc, html, callback, Input, Output, State, dash_table, no_update
@@ -52,6 +51,7 @@ def register_1d_stats_callbacks():
         Output('stats-1d__selected-variable', 'children'),
         Output('stats-1d__summary', 'children'),
         Output('stats-1d__categorical-chart', 'children'),
+        Output('stats-1d__chart', 'children', allow_duplicate=True),
         Input('1d-dropdown', 'value'),
         State('data-table', 'data'),
         State('stored-dtypes', 'data'),
@@ -66,9 +66,9 @@ def register_1d_stats_callbacks():
         values = df[col]
 
         if is_number_type(dtypes[col]):
-            return info, numeric_stats(values), no_update
+            return info, numeric_stats(values), None, None
         else:
-            return info, categorical_stats(values), html.Button('Wygeneruj wykres słupkowy', id="make-categorical-chart")
+            return info, categorical_stats(values), html.Button('Wygeneruj wykres słupkowy', id="make-categorical-chart"), None
 
     def numeric_stats(values):
         labels = [

--- a/eda/components/statistics_1d.py
+++ b/eda/components/statistics_1d.py
@@ -65,13 +65,13 @@ def register_1d_stats_callbacks():
         df = pd.DataFrame(data)
         values = df[col]
 
-        buttons = [html.Button('Wygeneruj wykres słupkowy', id="make-bar-chart")]
+        buttons = [html.Button('słupkowy', id="make-bar-chart")]
         if is_number_type(dtypes[col]):
-            buttons.append(html.Button('Wygeneruj wykres pudełkowy', id="make-box-chart"))
-            return info, numeric_stats(values), buttons, None
+            buttons.append(html.Button('pudełkowy', id="make-box-chart"))
+            return info, numeric_stats(values), ["Wygeneruj wykres: "] + buttons, None
         else:
-            buttons.append(html.Button('Wygeneruj wykres kołowy', id="make-pie-chart"))
-            return info, categorical_stats(values), buttons, None
+            buttons.append(html.Button('kołowy', id="make-pie-chart"))
+            return info, categorical_stats(values), ["Wygeneruj wykres: "] + buttons, None
 
     def numeric_stats(values):
         labels = [


### PR DESCRIPTION
Zmienne numeryczne posiadaja teraz wykresy: histogram, pudełkowy, skrzypcowy.
Zmienne kategoryczne: słupkowy sortowany malejącą liczbą wystąpień danej klasy i kołowy.